### PR TITLE
minor change

### DIFF
--- a/AwsCredentials.properties
+++ b/AwsCredentials.properties
@@ -1,2 +1,2 @@
-secretKey=
 accessKey=
+secretKey=


### PR DESCRIPTION
The AwsCredentials file listed the keys in order of 

secretKey=
accessKey=

I think the order should be reversed.
